### PR TITLE
Pd < 0.49 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.includes
 build**
 install/**
+
+.vscode/

--- a/pd/src/aoo_client.cpp
+++ b/pd/src/aoo_client.cpp
@@ -65,9 +65,13 @@ struct t_aoo_client
 
     t_priority_queue<t_peer_message> x_queue;
 
+#if PD_MINOR_VERSION < 49
+    bool check(const char *name);
+    bool check(int argc, t_atom *argv, int minargs, const char *name);
+#else
     bool check(const char *name) const;
-
     bool check(int argc, t_atom *argv, int minargs, const char *name) const;
+#endif
 
     void handle_message(AooId group, AooId user, AooNtpTime time, const AooData& msg);
 
@@ -106,7 +110,11 @@ struct t_aoo_client
     t_outlet *x_msgout = nullptr;
 };
 
+#if PD_MINOR_VERSION < 49
+bool t_aoo_client::check(const char *name)
+#else
 bool t_aoo_client::check(const char *name) const
+#endif
 {
     if (x_node){
         return true;
@@ -116,7 +124,11 @@ bool t_aoo_client::check(const char *name) const
     }
 }
 
+#if PD_MINOR_VERSION < 49
+bool t_aoo_client::check(int argc, t_atom *argv, int minargs, const char *name)
+#else
 bool t_aoo_client::check(int argc, t_atom *argv, int minargs, const char *name) const
+#endif
 {
     if (!check(name)) return false;
 

--- a/pd/src/aoo_common.cpp
+++ b/pd/src/aoo_common.cpp
@@ -332,7 +332,11 @@ int atoms_to_data(AooDataType type, int argc, const t_atom *argv,
     }
     auto ptr = data;
     for (int i = 0; i < argc; ++i) {
-        auto f = atom_getfloat(argv + i);
+#if PD_MINOR_VERSION < 49
+    auto f = atom_getfloat(const_cast<t_atom*>(argv + i));
+#else
+    auto f = atom_getfloat(argv + i);
+#endif
         switch (type) {
         case kAooDataFloat32:
             aoo::write_bytes<float>(f, ptr);

--- a/pd/src/aoo_receive~.cpp
+++ b/pd/src/aoo_receive~.cpp
@@ -71,18 +71,27 @@ struct t_aoo_receive
 
     t_priority_queue<t_stream_message> x_queue;
 
+#if PD_MINOR_VERSION < 49
+    bool get_source_arg(int argc, t_atom *argv,
+                        aoo::ip_address& addr, AooId& id, bool check);
+    bool check(const char *name);
+    bool check(int argc, t_atom *argv, int minargs, const char *name);
+#else
     bool get_source_arg(int argc, t_atom *argv,
                         aoo::ip_address& addr, AooId& id, bool check) const;
-
     bool check(const char *name) const;
-
     bool check(int argc, t_atom *argv, int minargs, const char *name) const;
+#endif
 
     void dispatch_stream_message(const AooStreamMessage& msg, const aoo::ip_address& address, AooId id);
 };
-
+#if PD_MINOR_VERSION < 49
+bool t_aoo_receive::get_source_arg(int argc, t_atom *argv,
+                                   aoo::ip_address& addr, AooId& id, bool check)
+#else
 bool t_aoo_receive::get_source_arg(int argc, t_atom *argv,
                                    aoo::ip_address& addr, AooId& id, bool check) const
+#endif
 {
     if (!x_node) {
         pd_error(this, "%s: no socket!", classname(this));
@@ -139,8 +148,11 @@ bool t_aoo_receive::get_source_arg(int argc, t_atom *argv,
         }
     }
 }
-
+#if PD_MINOR_VERSION < 49
+bool t_aoo_receive::check(const char *name)
+#else 
 bool t_aoo_receive::check(const char *name) const
+#endif
 {
     if (x_node){
         return true;
@@ -149,8 +161,11 @@ bool t_aoo_receive::check(const char *name) const
         return false;
     }
 }
-
+#if PD_MINOR_VERSION < 49
+bool t_aoo_receive::check(int argc, t_atom *argv, int minargs, const char *name)
+#else
 bool t_aoo_receive::check(int argc, t_atom *argv, int minargs, const char *name) const
+#endif
 {
     if (!check(name)) return false;
 

--- a/pd/src/aoo_send~.cpp
+++ b/pd/src/aoo_send~.cpp
@@ -70,12 +70,21 @@ struct t_aoo_send
     bool x_auto_invite = true; // on by default
     bool x_multi = false;
 
+#if PD_MINOR_VERSION < 49
+    bool get_sink_arg(int argc, t_atom *argv,
+                      aoo::ip_address& addr, AooId& id, bool check);
+
+    bool check(const char *name);
+
+    bool check(int argc, t_atom *argv, int minargs, const char *name);
+#else
     bool get_sink_arg(int argc, t_atom *argv,
                       aoo::ip_address& addr, AooId& id, bool check) const;
 
     bool check(const char *name) const;
 
     bool check(int argc, t_atom *argv, int minargs, const char *name) const;
+#endif
 
     void add_sink(const aoo::ip_address& addr, AooId id);
 
@@ -85,9 +94,13 @@ struct t_aoo_send
 
     const t_sink *find_sink(const aoo::ip_address& addr, AooId id) const;
 };
-
+#if PD_MINOR_VERSION < 49
+bool t_aoo_send::get_sink_arg(int argc, t_atom *argv,
+                              aoo::ip_address& addr, AooId& id, bool check)
+#else
 bool t_aoo_send::get_sink_arg(int argc, t_atom *argv,
                               aoo::ip_address& addr, AooId& id, bool check) const
+#endif
 {
     if (!x_node) {
         pd_error(this, "%s: no socket!", classname(this));
@@ -144,8 +157,11 @@ bool t_aoo_send::get_sink_arg(int argc, t_atom *argv,
         }
     }
 }
-
+#if PD_MINOR_VERSION < 49
+bool t_aoo_send::check(const char *name)
+#else
 bool t_aoo_send::check(const char *name) const
+#endif
 {
     if (x_node){
         return true;
@@ -155,7 +171,11 @@ bool t_aoo_send::check(const char *name) const
     }
 }
 
+#if PD_MINOR_VERSION < 49
+bool t_aoo_send::check(int argc, t_atom *argv, int minargs, const char *name)
+#else
 bool t_aoo_send::check(int argc, t_atom *argv, int minargs, const char *name) const
+#endif
 {
     if (!check(name)) return false;
 


### PR DESCRIPTION
This update patches the Pd externals for backward compatibility with Pd 0.48.

**Motivation**
As for today using Aoo on a Bela's stable release is not possible due to the lack of a modern compilation toolchain (the latest stable release [`v0.3.8h`](https://github.com/BelaPlatform/bela-image-builder/releases/tag/v0.3.8h) does not support c++17). On the other hand the 2022 unstable release ([`v0.5.0alpha2`](https://github.com/BelaPlatform/bela-image-builder/releases/tag/v0.5.0alpha2)) does. Still both releases host Pd 0.48.
